### PR TITLE
Implement GitHub OAuth connector and UI integration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,18 @@
+# Async Coder frontend configuration
+# Copy to .env.local at the project root and supply organization-specific values.
+
+# Base URL for the FastAPI backend. Should include the /api/v1 prefix.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api/v1
+# Legacy hook support: some hooks still reference NEXT_PUBLIC_API_URL.
+NEXT_PUBLIC_API_URL=http://localhost:8000/api/v1
+# URL used by API routes when calling the transcription endpoint server-side.
+BACKEND_URL=http://localhost:8000
+
+# Clerk authentication configuration
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_change-me
+CLERK_SECRET_KEY=sk_test_change-me
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+
+# GitHub connector documentation link override (optional)
+NEXT_PUBLIC_GITHUB_CONNECTOR_DOCS=https://github.com/your-org/async-coder/blob/main/docs/github-connector.md

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!.env.local.example
+!backend/.env.example
 
 # vercel
 .vercel
@@ -79,6 +82,9 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!.env.local.example
+!backend/.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -198,6 +198,17 @@ OPENAI_API_KEY=your_openai_key_here
 5. Use voice input or text to interact
 6. Connect your repositories and select branches
 
+### **5. Connect GitHub via MCP**
+
+The GitHub connector lets ChatGPT (or other MCP-compatible clients) talk to your repositories using OAuth. Follow the dedicated [GitHub connector setup guide](docs/github-connector.md) and the new environment samples (`backend/.env.example`, `.env.local.example`) to:
+
+- Register a GitHub App with the correct callback URL.
+- Populate the Async Coder backend with your GitHub credentials.
+- Launch the **Authorize with GitHub** flow directly from **Settings → Integrations** without intermediary pop-ups.
+- Verify connection status and scopes inside the dashboard.
+
+Once connected, update your MCP discovery document so ChatGPT can call the connector endpoints exposed by the FastAPI backend.
+
 **CLI Mode (Coming Soon):**
 ```bash
 # Launch interactive mode

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,75 @@
+# Async Coder backend configuration
+# Copy this file to backend/.env and replace placeholder values.
+
+# -----------------------------------------------------------------------------
+# Core application settings
+# -----------------------------------------------------------------------------
+APP_NAME=Async Coder API
+APP_VERSION=1.0.0
+DEBUG=true
+ENVIRONMENT=development
+HOST=0.0.0.0
+PORT=8000
+API_V1_PREFIX=/api/v1
+
+# URL of the frontend dashboard. Used when redirecting back from GitHub OAuth.
+FRONTEND_BASE_URL=http://localhost:3000
+
+# Secret key used for signing cookies and other security primitives.
+SECRET_KEY=change-me
+ALLOWED_HOSTS=["*"]
+
+# CORS configuration. Provide the frontend origin(s) that can call the backend.
+CORS_ORIGINS=["http://localhost:3000"]
+CORS_ALLOW_CREDENTIALS=true
+CORS_ALLOW_METHODS=["*"]
+CORS_ALLOW_HEADERS=["*"]
+
+# -----------------------------------------------------------------------------
+# Database and Supabase configuration
+# -----------------------------------------------------------------------------
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/async_coder
+SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_PUBLIC_KEY=your-supabase-service-role-key
+
+# -----------------------------------------------------------------------------
+# Groq (LLM) integration
+# -----------------------------------------------------------------------------
+GROQ_API_KEY=your-groq-api-key
+GROQ_BASE_URL=https://api.groq.com/openai/v1
+GROQ_TIMEOUT=30
+GROQ_MAX_RETRIES=2
+
+# -----------------------------------------------------------------------------
+# Audio processing
+# -----------------------------------------------------------------------------
+MAX_FILE_SIZE_MB=25
+ALLOWED_AUDIO_FORMATS=["flac","mp3","mp4","mpeg","mpga","m4a","ogg","wav","webm"]
+DEFAULT_MODEL=whisper-large-v3-turbo
+AVAILABLE_MODELS=["whisper-large-v3-turbo","whisper-large-v3"]
+
+# -----------------------------------------------------------------------------
+# GitHub OAuth / App connector configuration
+# These values must match the GitHub App or OAuth app you configure.
+# -----------------------------------------------------------------------------
+GITHUB_APP_ID=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+# Paste the PEM-encoded private key in a single line or escape newlines (\n).
+GITHUB_PRIVATE_KEY=
+GITHUB_WEBHOOK_SECRET=
+# Callback URL registered with GitHub. Use the FastAPI endpoint below in dev.
+GITHUB_REDIRECT_URI=http://localhost:8000/api/v1/github/oauth/callback
+GITHUB_AUTHORIZE_URL=https://github.com/login/oauth/authorize
+GITHUB_TOKEN_URL=https://github.com/login/oauth/access_token
+GITHUB_API_BASE_URL=https://api.github.com
+GITHUB_OAUTH_SCOPES=["repo","read:org"]
+
+# -----------------------------------------------------------------------------
+# Logging and storage
+# -----------------------------------------------------------------------------
+LOG_LEVEL=INFO
+LOG_FORMAT=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+LOG_FILE_PATH=logs/app.log
+UPLOAD_DIR=uploads
+TEMP_FILE_CLEANUP=true

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,9 +25,9 @@ The server listens on `http://localhost:8000` by default and mounts all routes u
 
 | Method & Path | Description |
 | --- | --- |
-| `POST /api/v1/github/oauth/start` | Generates an authorization URL and state token for the signed-in user. |
+| `POST /api/v1/github/oauth/start` | Generates an authorization URL and state token for the signed-in user (requires `Authorization: Bearer <token>`). |
 | `GET /api/v1/github/oauth/callback` | Exchanges the GitHub `code` for tokens and redirects back to the frontend with the outcome. |
-| `GET /api/v1/github/oauth/status` | Returns the stored connection metadata for a `user_id` (connected flag, account info, scopes, timestamp). |
+| `GET /api/v1/github/oauth/status` | Returns the stored connection metadata for the authenticated caller (connected flag, account info, scopes, timestamp). |
 
 These endpoints rely on the configuration described in [`docs/github-connector.md`](../docs/github-connector.md). For production deployments replace the in-memory token storage in `GitHubOAuthService` with calls to your database or secret store.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,51 @@
+# Async Coder Backend
+
+This directory hosts the FastAPI application that powers Async Coder. It exposes transcription services, API-key management, and the GitHub OAuth connector that integrates with OpenAI's Model Context Protocol (MCP) custom connectors.
+
+## Getting started
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+uvicorn main:app --reload
+```
+
+The server listens on `http://localhost:8000` by default and mounts all routes under the `/api/v1` prefix. Update `.env` to match your environment—see the sample file for guidance.
+
+## Key packages
+
+- `app/api/v1/endpoints` – FastAPI routers for transcription, API-key management, and GitHub OAuth.
+- `app/services` – Business logic (e.g. `GitHubOAuthService`) used by the endpoints.
+- `app/core/config.py` – Pydantic settings loader for all environment variables.
+
+## GitHub OAuth endpoints
+
+| Method & Path | Description |
+| --- | --- |
+| `POST /api/v1/github/oauth/start` | Generates an authorization URL and state token for the signed-in user. |
+| `GET /api/v1/github/oauth/callback` | Exchanges the GitHub `code` for tokens and redirects back to the frontend with the outcome. |
+| `GET /api/v1/github/oauth/status` | Returns the stored connection metadata for a `user_id` (connected flag, account info, scopes, timestamp). |
+
+These endpoints rely on the configuration described in [`docs/github-connector.md`](../docs/github-connector.md). For production deployments replace the in-memory token storage in `GitHubOAuthService` with calls to your database or secret store.
+
+## Useful environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `FRONTEND_BASE_URL` | Determines where users are redirected after OAuth completes (`/task/settings?tab=integrations`). |
+| `GITHUB_REDIRECT_URI` | Must match the callback URL registered in your GitHub App. |
+| `GITHUB_OAUTH_SCOPES` | Customise the scopes that appear on GitHub's Install & Authorize screen. |
+| `GROQ_API_KEY` | Required for Groq transcription requests. |
+
+Consult [`backend/.env.example`](./.env.example) for the complete list.
+
+## Running tests
+
+```bash
+pytest
+```
+
+The existing test suite covers the API-key management flow. Add your own tests to exercise `GitHubOAuthService` once you introduce persistent storage or extend the connector.

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,0 +1,18 @@
+"""Shared API dependencies for FastAPI endpoints."""
+from __future__ import annotations
+
+from fastapi import Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+
+security = HTTPBearer()
+
+
+def get_current_user_id(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> str:
+    """Extract the authenticated user identifier from the request."""
+    # TODO: Replace mock implementation with JWT validation or session lookup.
+    # This placeholder mirrors the existing API key endpoints.
+    _ = credentials  # pragma: no cover - to silence unused variable in placeholder
+    return "mock-user-id"

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -3,10 +3,11 @@ API v1 router configuration.
 """
 
 from fastapi import APIRouter
-from .endpoints import transcription, api_keys
+from .endpoints import transcription, api_keys, github
 
 api_router = APIRouter()
 
 # Include endpoint routers
 api_router.include_router(transcription.router)
 api_router.include_router(api_keys.router)
+api_router.include_router(github.router)

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -3,7 +3,8 @@ API v1 router configuration.
 """
 
 from fastapi import APIRouter
-from .endpoints import transcription, api_keys, github
+
+from .endpoints import api_keys, github, transcription
 
 api_router = APIRouter()
 

--- a/backend/app/api/v1/endpoints/api_keys.py
+++ b/backend/app/api/v1/endpoints/api_keys.py
@@ -3,16 +3,15 @@ API Key management endpoints.
 """
 
 from fastapi import APIRouter, HTTPException, Depends, status
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from typing import List, Dict, Any, Optional
 import logging
 from pydantic import BaseModel, Field
 
 from app.database.api_keys import APIKeyManager
 from app.services.api_key_validator import APIKeyValidationService
+from app.api.deps import get_current_user_id
 
 logger = logging.getLogger(__name__)
-security = HTTPBearer()
 
 router = APIRouter(prefix="/api-keys", tags=["api-keys"])
 
@@ -55,12 +54,6 @@ class ProviderResponse(BaseModel):
     website_url: Optional[str]
     docs_url: Optional[str]
     configuration: Dict[str, Any]
-
-def get_current_user_id(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
-    """Extract user ID from JWT token. This is a placeholder - implement actual JWT validation."""
-    # TODO: Implement proper JWT token validation
-    # For now, return a mock user ID
-    return "mock-user-id"
 
 @router.get("/providers", response_model=List[ProviderResponse])
 async def get_providers():

--- a/backend/app/api/v1/endpoints/github.py
+++ b/backend/app/api/v1/endpoints/github.py
@@ -1,0 +1,144 @@
+"""FastAPI endpoints for managing the GitHub OAuth connector."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import RedirectResponse
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+from app.core.config import Settings, get_settings
+from app.services.github_oauth_service import (
+    GitHubOAuthConfigurationError,
+    GitHubOAuthError,
+    GitHubOAuthService,
+    GitHubOAuthStateError,
+)
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/github", tags=["GitHub OAuth"])
+
+
+def get_github_service(settings: Settings = Depends(get_settings)) -> GitHubOAuthService:
+    """Provide a GitHub OAuth service instance."""
+    # Using a module-level cache ensures state persistence within the process.
+    if not hasattr(get_github_service, "_instance"):
+        setattr(get_github_service, "_instance", GitHubOAuthService(settings))
+    return getattr(get_github_service, "_instance")
+
+
+class OAuthStartRequest(BaseModel):
+    """Request payload for starting the OAuth flow."""
+
+    user_id: Optional[str] = Field(default=None, description="Authenticated user identifier")
+    return_url: Optional[AnyHttpUrl] = Field(
+        default=None,
+        description="URL to redirect back to once OAuth completes",
+    )
+
+
+class OAuthStartResponse(BaseModel):
+    """Response describing the GitHub authorization URL."""
+
+    authorization_url: AnyHttpUrl = Field(alias="authorizationUrl")
+    state: str
+    expires_in: int = Field(alias="expiresIn")
+
+    class Config:
+        populate_by_name = True
+
+
+class GitHubAccount(BaseModel):
+    """Simplified GitHub account details for the frontend."""
+
+    login: Optional[str] = None
+    name: Optional[str] = None
+    avatar_url: Optional[AnyHttpUrl] = Field(default=None, alias="avatarUrl")
+    html_url: Optional[AnyHttpUrl] = Field(default=None, alias="htmlUrl")
+
+    class Config:
+        populate_by_name = True
+
+
+class GitHubConnectionStatus(BaseModel):
+    """Connection status returned to the frontend."""
+
+    connected: bool
+    account: Optional[GitHubAccount] = None
+    scopes: list[str] = Field(default_factory=list)
+    connected_at: Optional[str] = Field(default=None, alias="connectedAt")
+
+    class Config:
+        populate_by_name = True
+
+
+@router.post("/oauth/start", response_model=OAuthStartResponse)
+async def start_github_oauth(
+    payload: OAuthStartRequest,
+    service: GitHubOAuthService = Depends(get_github_service),
+) -> OAuthStartResponse:
+    """Begin the GitHub OAuth flow by generating an authorization URL."""
+    try:
+        authorization_url, state = service.start_authorization(
+            user_id=payload.user_id,
+            return_url=str(payload.return_url) if payload.return_url else None,
+        )
+    except GitHubOAuthConfigurationError as exc:
+        logger.error("GitHub OAuth configuration error: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except GitHubOAuthStateError as exc:
+        logger.warning("GitHub OAuth state error: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return OAuthStartResponse(
+        authorization_url=authorization_url,
+        state=state,
+        expires_in=service.state_ttl_seconds,
+    )
+
+
+@router.get("/oauth/callback")
+async def github_oauth_callback(
+    code: str = Query(..., description="GitHub authorization code"),
+    state: str = Query(..., description="OAuth state token"),
+    service: GitHubOAuthService = Depends(get_github_service),
+) -> RedirectResponse:
+    """Handle the OAuth callback from GitHub."""
+    try:
+        result = await service.complete_authorization(code=code, state=state)
+        redirect_url = result["redirect_url"]
+    except GitHubOAuthStateError as exc:
+        logger.warning("GitHub OAuth callback failed due to state error: %s", exc)
+        redirect_url = service.build_error_redirect(state=state, error_code=exc.code)
+    except GitHubOAuthError as exc:
+        logger.error("GitHub OAuth callback failed: %s", exc)
+        redirect_url = service.build_error_redirect(
+            state=state,
+            error_code=exc.code,
+            return_url=getattr(exc, "return_url", None),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Unexpected error while handling GitHub callback: %s", exc)
+        redirect_url = service.build_error_redirect(state=state, error_code="unexpected")
+
+    return RedirectResponse(url=redirect_url, status_code=303)
+
+
+@router.get("/oauth/status", response_model=GitHubConnectionStatus)
+async def github_connection_status(
+    user_id: str = Query(..., description="Authenticated user identifier"),
+    service: GitHubOAuthService = Depends(get_github_service),
+) -> GitHubConnectionStatus:
+    """Return the GitHub connector status for the current user."""
+    status_payload = service.get_connection_status(user_id)
+    account_payload = status_payload.get("account") if status_payload.get("connected") else None
+
+    return GitHubConnectionStatus(
+        connected=status_payload.get("connected", False),
+        account=GitHubAccount(**account_payload) if account_payload else None,
+        scopes=status_payload.get("scopes", []),
+        connected_at=status_payload.get("connected_at"),
+    )

--- a/backend/app/api/v1/endpoints/github.py
+++ b/backend/app/api/v1/endpoints/github.py
@@ -15,6 +15,7 @@ from app.services.github_oauth_service import (
     GitHubOAuthService,
     GitHubOAuthStateError,
 )
+from app.api.deps import get_current_user_id
 
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,6 @@ def get_github_service(settings: Settings = Depends(get_settings)) -> GitHubOAut
 class OAuthStartRequest(BaseModel):
     """Request payload for starting the OAuth flow."""
 
-    user_id: Optional[str] = Field(default=None, description="Authenticated user identifier")
     return_url: Optional[AnyHttpUrl] = Field(
         default=None,
         description="URL to redirect back to once OAuth completes",
@@ -78,12 +78,13 @@ class GitHubConnectionStatus(BaseModel):
 @router.post("/oauth/start", response_model=OAuthStartResponse)
 async def start_github_oauth(
     payload: OAuthStartRequest,
+    user_id: str = Depends(get_current_user_id),
     service: GitHubOAuthService = Depends(get_github_service),
 ) -> OAuthStartResponse:
     """Begin the GitHub OAuth flow by generating an authorization URL."""
     try:
         authorization_url, state = service.start_authorization(
-            user_id=payload.user_id,
+            user_id=user_id,
             return_url=str(payload.return_url) if payload.return_url else None,
         )
     except GitHubOAuthConfigurationError as exc:
@@ -129,7 +130,7 @@ async def github_oauth_callback(
 
 @router.get("/oauth/status", response_model=GitHubConnectionStatus)
 async def github_connection_status(
-    user_id: str = Query(..., description="Authenticated user identifier"),
+    user_id: str = Depends(get_current_user_id),
     service: GitHubOAuthService = Depends(get_github_service),
 ) -> GitHubConnectionStatus:
     """Return the GitHub connector status for the current user."""

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -31,6 +31,12 @@ class Settings(BaseSettings):
     port: int = Field(default=8000, env="PORT")
     api_v1_prefix: str = Field(default="/api/v1", env="API_V1_PREFIX")
 
+    # Frontend configuration
+    frontend_base_url: str = Field(
+        default="http://localhost:3000",
+        env="FRONTEND_BASE_URL",
+    )
+
     # Security Configuration
     secret_key: str = Field(
         default="your-secret-key-here-change-in-production",
@@ -70,6 +76,30 @@ class Settings(BaseSettings):
     available_models: List[str] | str = Field(
         default=["whisper-large-v3-turbo", "whisper-large-v3"],
         env="AVAILABLE_MODELS",
+    )
+
+    # GitHub OAuth Configuration
+    github_app_id: Optional[str] = Field(default=None, env="GITHUB_APP_ID")
+    github_client_id: Optional[str] = Field(default=None, env="GITHUB_CLIENT_ID")
+    github_client_secret: Optional[str] = Field(default=None, env="GITHUB_CLIENT_SECRET")
+    github_private_key: Optional[str] = Field(default=None, env="GITHUB_PRIVATE_KEY")
+    github_webhook_secret: Optional[str] = Field(default=None, env="GITHUB_WEBHOOK_SECRET")
+    github_redirect_uri: Optional[str] = Field(default=None, env="GITHUB_REDIRECT_URI")
+    github_authorize_url: str = Field(
+        default="https://github.com/login/oauth/authorize",
+        env="GITHUB_AUTHORIZE_URL",
+    )
+    github_token_url: str = Field(
+        default="https://github.com/login/oauth/access_token",
+        env="GITHUB_TOKEN_URL",
+    )
+    github_api_base_url: str = Field(
+        default="https://api.github.com",
+        env="GITHUB_API_BASE_URL",
+    )
+    github_oauth_scopes: List[str] | str = Field(
+        default=["repo", "read:org"],
+        env="GITHUB_OAUTH_SCOPES",
     )
 
     # Logging Configuration
@@ -118,6 +148,7 @@ class Settings(BaseSettings):
         "cors_allow_headers",
         "allowed_audio_formats",
         "available_models",
+        "github_oauth_scopes",
         mode="before",
     )
     def parse_list_fields(cls, value: Any) -> List[str]:

--- a/backend/app/services/github_oauth_service.py
+++ b/backend/app/services/github_oauth_service.py
@@ -1,0 +1,332 @@
+"""GitHub OAuth service helpers for the Async Coder backend."""
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+import httpx
+
+from app.core.config import Settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubOAuthError(Exception):
+    """Base exception for GitHub OAuth issues."""
+
+    def __init__(self, message: str, code: str = "oauth_error", return_url: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.return_url = return_url
+
+
+class GitHubOAuthConfigurationError(GitHubOAuthError):
+    """Raised when required GitHub configuration is missing."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, code="configuration")
+
+
+class GitHubOAuthStateError(GitHubOAuthError):
+    """Raised when an OAuth state token is invalid or expired."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, code="invalid_state")
+
+
+class GitHubOAuthService:
+    """Handles OAuth authorization flows against GitHub."""
+
+    STATE_TTL = timedelta(minutes=10)
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self._state_store: Dict[str, Dict[str, Any]] = {}
+        self._connections: Dict[str, Dict[str, Any]] = {}
+        self._credentials: Dict[str, Dict[str, Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    @property
+    def state_ttl_seconds(self) -> int:
+        """Return the TTL for state tokens in seconds."""
+        return int(self.STATE_TTL.total_seconds())
+
+    def start_authorization(self, *, user_id: Optional[str], return_url: Optional[str]) -> tuple[str, str]:
+        """Create an authorization URL and state token for a user."""
+        self._ensure_configuration()
+        self._cleanup_expired_states()
+
+        sanitized_return_url = self._sanitize_return_url(return_url)
+        state = secrets.token_urlsafe(32)
+        self._state_store[state] = {
+            "user_id": user_id,
+            "return_url": sanitized_return_url,
+            "created_at": datetime.utcnow(),
+        }
+
+        authorize_url = self._build_authorize_url(state)
+        logger.info("Created GitHub OAuth state for user %s", user_id or "anonymous")
+        return authorize_url, state
+
+    async def complete_authorization(self, *, state: str, code: str) -> Dict[str, Any]:
+        """Exchange the authorization code for a token and persist the connection."""
+        state_data = self._consume_state(state)
+        if not state_data:
+            raise GitHubOAuthStateError("OAuth state is invalid or has expired.")
+
+        try:
+            token_payload = await self._exchange_code_for_token(code)
+            access_token = token_payload.get("access_token")
+            if not access_token:
+                raise GitHubOAuthError(
+                    "GitHub did not return an access token.",
+                    code="token_exchange_failed",
+                    return_url=state_data.get("return_url"),
+                )
+
+            user_profile = await self._fetch_user_profile(access_token)
+            connection = self._persist_connection(
+                user_id=state_data.get("user_id"),
+                token_payload=token_payload,
+                user_profile=user_profile,
+            )
+            redirect_url = self._build_redirect_url(
+                state_data.get("return_url"),
+                status="connected",
+            )
+            logger.info(
+                "GitHub OAuth completed for user %s (login=%s)",
+                state_data.get("user_id") or "anonymous",
+                user_profile.get("login"),
+            )
+            return {
+                "redirect_url": redirect_url,
+                "connection": connection,
+            }
+        except GitHubOAuthError as exc:
+            exc.return_url = exc.return_url or state_data.get("return_url")
+            raise
+        except httpx.HTTPStatusError as exc:
+            logger.error("GitHub token exchange failed: %s", exc)
+            raise GitHubOAuthError(
+                "GitHub token endpoint returned an error.",
+                code="token_exchange_failed",
+                return_url=state_data.get("return_url"),
+            ) from exc
+        except httpx.RequestError as exc:
+            logger.error("GitHub token exchange request failed: %s", exc)
+            raise GitHubOAuthError(
+                "Unable to reach GitHub token endpoint.",
+                code="network_failure",
+                return_url=state_data.get("return_url"),
+            ) from exc
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Unexpected error completing GitHub OAuth: %s", exc)
+            raise GitHubOAuthError(
+                "Unexpected error completing GitHub OAuth.",
+                return_url=state_data.get("return_url"),
+            ) from exc
+
+    def build_error_redirect(
+        self,
+        *,
+        state: Optional[str],
+        error_code: str,
+        return_url: Optional[str] = None,
+    ) -> str:
+        """Create a redirect URL for error cases."""
+        target_url = return_url
+        if not target_url and state and state in self._state_store:
+            state_data = self._consume_state(state)
+            if state_data:
+                target_url = state_data.get("return_url")
+        return self._build_redirect_url(target_url, status="error", error_code=error_code)
+
+    def get_connection_status(self, user_id: Optional[str]) -> Dict[str, Any]:
+        """Return connection metadata for a user."""
+        if not user_id:
+            return {"connected": False}
+
+        connection = self._connections.get(user_id)
+        if not connection:
+            return {"connected": False}
+
+        return {
+            "connected": True,
+            "account": connection.get("account"),
+            "scopes": connection.get("scopes", []),
+            "connected_at": connection.get("connected_at"),
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_configuration(self) -> None:
+        missing = []
+        if not self.settings.github_client_id:
+            missing.append("GITHUB_CLIENT_ID")
+        if not self.settings.github_client_secret:
+            missing.append("GITHUB_CLIENT_SECRET")
+        if not self.settings.github_redirect_uri:
+            missing.append("GITHUB_REDIRECT_URI")
+
+        if missing:
+            raise GitHubOAuthConfigurationError(
+                "Missing GitHub OAuth configuration: " + ", ".join(missing)
+            )
+
+    def _cleanup_expired_states(self) -> None:
+        now = datetime.utcnow()
+        expired = [
+            state
+            for state, meta in self._state_store.items()
+            if now - meta.get("created_at", now) > self.STATE_TTL
+        ]
+        for state in expired:
+            logger.debug("Cleaning up expired OAuth state %s", state)
+            self._state_store.pop(state, None)
+
+    def _sanitize_return_url(self, return_url: Optional[str]) -> str:
+        default_base = self._default_return_base()
+        if not return_url:
+            return default_base
+
+        parsed = urlparse(return_url)
+        if not parsed.scheme or not parsed.netloc:
+            raise GitHubOAuthStateError("Return URL must be absolute.")
+
+        allowed_origin = urlparse(default_base)
+        if parsed.scheme != allowed_origin.scheme or parsed.netloc != allowed_origin.netloc:
+            raise GitHubOAuthStateError("Return URL host is not permitted.")
+
+        return return_url
+
+    def _default_return_base(self) -> str:
+        base = (self.settings.frontend_base_url or "http://localhost:3000").rstrip("/")
+        return f"{base}/task/settings?tab=integrations"
+
+    def _build_authorize_url(self, state: str) -> str:
+        scopes = self.settings.github_oauth_scopes
+        if isinstance(scopes, list):
+            scope_param = " ".join(scopes)
+        else:
+            scope_param = str(scopes)
+
+        query = {
+            "client_id": self.settings.github_client_id,
+            "redirect_uri": self.settings.github_redirect_uri,
+            "state": state,
+            "allow_signup": "false",
+        }
+        if scope_param:
+            query["scope"] = scope_param
+
+        parsed = urlparse(self.settings.github_authorize_url)
+        base = parsed._replace(query="")
+        return urlunparse(base) + "?" + urlencode(query)
+
+    def _consume_state(self, state: str) -> Optional[Dict[str, Any]]:
+        data = self._state_store.pop(state, None)
+        if not data:
+            return None
+        if datetime.utcnow() - data.get("created_at", datetime.utcnow()) > self.STATE_TTL:
+            logger.info("Discarded expired OAuth state %s", state)
+            return None
+        return data
+
+    async def _exchange_code_for_token(self, code: str) -> Dict[str, Any]:
+        payload = {
+            "client_id": self.settings.github_client_id,
+            "client_secret": self.settings.github_client_secret,
+            "code": code,
+            "redirect_uri": self.settings.github_redirect_uri,
+        }
+        headers = {"Accept": "application/json"}
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.post(
+                self.settings.github_token_url,
+                data=payload,
+                headers=headers,
+            )
+            response.raise_for_status()
+            data = response.json()
+            if data.get("error"):
+                logger.error("GitHub token exchange error: %s", data)
+                raise GitHubOAuthError(
+                    data.get("error_description") or "GitHub token exchange failed.",
+                    code="token_exchange_failed",
+                )
+            return data
+
+    async def _fetch_user_profile(self, access_token: str) -> Dict[str, Any]:
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/vnd.github+json",
+        }
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(
+                f"{self.settings.github_api_base_url.rstrip('/')}/user",
+                headers=headers,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    def _persist_connection(
+        self,
+        *,
+        user_id: Optional[str],
+        token_payload: Dict[str, Any],
+        user_profile: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        scopes = self._parse_scopes(token_payload.get("scope"))
+        connection = {
+            "account": {
+                "login": user_profile.get("login"),
+                "name": user_profile.get("name"),
+                "avatar_url": user_profile.get("avatar_url"),
+                "html_url": user_profile.get("html_url"),
+            },
+            "scopes": scopes,
+            "connected_at": datetime.utcnow().isoformat(),
+        }
+
+        if user_id:
+            self._connections[user_id] = connection
+            self._credentials[user_id] = {
+                "access_token": token_payload.get("access_token"),
+                "token_type": token_payload.get("token_type"),
+                "scope": scopes,
+                "refresh_token": token_payload.get("refresh_token"),
+                "expires_in": token_payload.get("expires_in"),
+            }
+
+        return connection
+
+    def _parse_scopes(self, scopes: Optional[str]) -> list[str]:
+        if not scopes:
+            return []
+        return [scope.strip() for scope in scopes.replace(",", " ").split() if scope.strip()]
+
+    def _build_redirect_url(self, return_url: Optional[str], *, status: str, error_code: Optional[str] = None) -> str:
+        base = return_url or self._default_return_base()
+        parsed = urlparse(base)
+        query = dict(parse_qsl(parsed.query))
+        query["github"] = status
+        if error_code:
+            query["error"] = error_code
+        new_query = urlencode(query, doseq=True)
+        return urlunparse(parsed._replace(query=new_query))
+
+
+__all__ = [
+    "GitHubOAuthService",
+    "GitHubOAuthError",
+    "GitHubOAuthConfigurationError",
+    "GitHubOAuthStateError",
+]

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from fastapi.exceptions import RequestValidationError
 import uvicorn
 
 from app.core.config import get_settings
-from app.api.v1.endpoints.transcription import router as transcription_router
+from app.api.v1 import api_router
 from app.providers.groq_provider import GroqAPIError
 
 # Configure logging with colors
@@ -381,11 +381,7 @@ async def basic_health_check() -> Dict[str, Any]:
 
 
 # Include API routers
-app.include_router(
-    transcription_router,
-    prefix=settings.api_v1_prefix,
-    tags=["Audio Transcription"]
-)
+app.include_router(api_router, prefix=settings.api_v1_prefix)
 
 
 # Custom startup message

--- a/docs/github-connector.md
+++ b/docs/github-connector.md
@@ -1,0 +1,130 @@
+# GitHub Connector Setup
+
+This guide explains how to wire Async Coder to GitHub using OAuth and the Model Context Protocol (MCP) connector architecture. It covers the GitHub App configuration, backend API endpoints, frontend behaviour, and the environment variables required to run the flow locally or in production.
+
+> **TL;DR**
+> 1. Register a GitHub App (or OAuth App) with the callback URL `https://<your-backend-domain>/api/v1/github/oauth/callback`.
+> 2. Copy the credentials into `backend/.env` (see `backend/.env.example`) and `/.env.local`.
+> 3. Start the FastAPI backend and Next.js frontend.
+> 4. Visit **Settings → Integrations → GitHub connector** and click **Authorize with GitHub**. You should land on GitHub's native Install & Authorize page.
+> 5. After approving, Async Coder redirects back with the connection status and surfaces the account details.
+
+---
+
+## 1. GitHub App configuration
+
+1. Navigate to **GitHub → Settings → Developer settings → GitHub Apps → New GitHub App**.
+2. Fill in the basic metadata (name, homepage URL, description).
+3. Under **Webhook**, set a secret if you want to receive events (optional but recommended).
+4. Under **Permissions**, grant the minimal scopes required, for example:
+   - Repository contents: **Read-only**
+   - Metadata: **Read-only**
+   - Issues / Pull requests: **Read-only** (if you intend to surface them via MCP)
+5. Under **Where can this GitHub App be installed?**, choose "Any account" unless you want to restrict it to a single organisation.
+6. Set the **Callback URL** to `https://<your-backend-domain>/api/v1/github/oauth/callback` (use `http://localhost:8000/api/v1/github/oauth/callback` in development).
+7. Save the app and record the following values:
+   - **App ID**
+   - **Client ID**
+   - **Client Secret**
+   - **Private key** (download the PEM file)
+   - **Webhook secret** (if configured)
+
+If you prefer the classic OAuth App flow you can re-use the same endpoints; the backend exchanges the `code` for an access token at `https://github.com/login/oauth/access_token`.
+
+---
+
+## 2. Backend configuration (`backend/.env`)
+
+The FastAPI backend uses `app/core/config.py` to load environment variables. Copy `backend/.env.example` to `backend/.env` and populate the GitHub fields with the values from your GitHub App.
+
+| Variable | Description |
+| --- | --- |
+| `GITHUB_APP_ID` | Numeric identifier of the GitHub App. Required when minting installation tokens. |
+| `GITHUB_CLIENT_ID` | OAuth client ID. Used when generating the authorization URL and exchanging the code. |
+| `GITHUB_CLIENT_SECRET` | OAuth client secret. Required for the token exchange. |
+| `GITHUB_PRIVATE_KEY` | PEM-formatted private key. Paste as a single line with `\n` escaped or use a multiline value in your hosting provider's secret manager. |
+| `GITHUB_WEBHOOK_SECRET` | Shared secret for validating webhook payloads. Optional but strongly recommended. |
+| `GITHUB_REDIRECT_URI` | Must match the callback URL registered on the GitHub App. Defaults to `http://localhost:8000/api/v1/github/oauth/callback`. |
+| `GITHUB_OAUTH_SCOPES` | List or comma-separated string of scopes requested during authorization. Defaults to `repo, read:org`. |
+| `FRONTEND_BASE_URL` | Base URL of the dashboard. Used when redirecting back to `/task/settings?tab=integrations`. |
+
+Other backend variables (database, Supabase, Groq, etc.) remain unchanged—see the sample file for defaults.
+
+---
+
+## 3. Frontend configuration (`.env.local`)
+
+Copy `.env.local.example` to `.env.local` and confirm the following values:
+
+| Variable | Description |
+| --- | --- |
+| `NEXT_PUBLIC_API_BASE_URL` | Points the UI to the FastAPI backend (`http://localhost:8000/api/v1` in development). |
+| `NEXT_PUBLIC_API_URL` | Legacy alias used by older hooks. Keep this identical to `NEXT_PUBLIC_API_BASE_URL`. |
+| `BACKEND_URL` | Used by API routes when proxying transcription requests. |
+| `NEXT_PUBLIC_CLERK_*` / `CLERK_SECRET_KEY` | Clerk authentication keys. Without these the dashboard will redirect to the sign-in screen. |
+| `NEXT_PUBLIC_GITHUB_CONNECTOR_DOCS` | Optional override for the "Open the full setup guide" button shown in Settings. |
+
+Restart the Next.js dev server after editing `.env.local` so new environment variables are picked up.
+
+---
+
+## 4. Backend API endpoints
+
+The following endpoints live under `/api/v1/github`:
+
+| Method & Path | Purpose |
+| --- | --- |
+| `POST /oauth/start` | Generates a GitHub authorization URL and opaque state token. Requires `user_id` in the payload. |
+| `GET /oauth/callback` | Handles the GitHub redirect, exchanges the `code` for an access token or installation token, and redirects back to the frontend with `github=connected` or `github=error`. |
+| `GET /oauth/status` | Returns the connection status for a given `user_id` (connected flag, account info, scopes, timestamp). |
+
+All endpoints rely on in-memory storage for demo purposes. Replace `GitHubOAuthService` with your persistence layer before shipping to production.
+
+---
+
+## 5. Frontend behaviour
+
+The **Integrations → GitHub connector** tab:
+
+1. Calls `GET /github/oauth/status` on mount when a user is signed in.
+2. Launches the GitHub OAuth flow by POSTing to `/github/oauth/start` and redirecting the browser to the returned URL.
+3. Listens for `github=connected` or `github=error` query parameters after the backend redirects back.
+4. Shows the connected account, scopes, and "Connected X minutes ago" timestamp.
+5. Links to this document so operators can review configuration steps without digging into the repository.
+
+The button labelled **Authorize with GitHub** opens GitHub's native Install & Authorize page directly—no intermediate popups.
+
+---
+
+## 6. MCP connector considerations
+
+* Update your MCP discovery document to reference the FastAPI OAuth endpoints with absolute URLs.
+* Map ChatGPT user identifiers to GitHub installation tokens in your datastore. The included implementation keeps them in memory for brevity.
+* Refresh installation access tokens before they expire (typically every hour for GitHub Apps). The service exposes the raw token payload so you can persist the expiry metadata.
+* Handle webhook events (`installation`, `installation_repositories`, `installation_target`) if you need to respond to repo access changes.
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Redirect loops back to `/task/settings` with `github=error&error=configuration` | Missing GitHub credentials in `backend/.env`. | Double-check `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `GITHUB_REDIRECT_URI`. |
+| GitHub shows `redirect_uri_mismatch` | The callback URL in your GitHub App does not match `GITHUB_REDIRECT_URI`. | Update the GitHub App or environment variable so both values match exactly. |
+| State mismatch error | The authorization link expired (default TTL is 10 minutes). | Retry the connection or increase `STATE_TTL` in `GitHubOAuthService`. |
+| Avatar images blocked in UI | `next.config.ts` is missing the GitHub avatars domain. | Already configured in this repository; ensure your production Next.js build includes the same entry. |
+
+If you run into other issues, check the FastAPI logs around `GitHubOAuthService` for context—the service logs state lifecycle and token exchanges.
+
+---
+
+## 8. Next steps
+
+Once GitHub connectivity works end-to-end you can extend the connector to:
+
+- Persist installation tokens in your database.
+- Offer repository-scoped controls directly in the Async Coder UI.
+- Implement MCP methods (e.g. `listRepos`, `getFile`, `searchCode`).
+- Sync GitHub events into Async Coder's task timelines.
+
+Happy connecting!

--- a/docs/github-connector.md
+++ b/docs/github-connector.md
@@ -74,9 +74,9 @@ The following endpoints live under `/api/v1/github`:
 
 | Method & Path | Purpose |
 | --- | --- |
-| `POST /oauth/start` | Generates a GitHub authorization URL and opaque state token. Requires `user_id` in the payload. |
+| `POST /oauth/start` | Generates a GitHub authorization URL and opaque state token. Requires an `Authorization` bearer token so the backend can resolve the caller. |
 | `GET /oauth/callback` | Handles the GitHub redirect, exchanges the `code` for an access token or installation token, and redirects back to the frontend with `github=connected` or `github=error`. |
-| `GET /oauth/status` | Returns the connection status for a given `user_id` (connected flag, account info, scopes, timestamp). |
+| `GET /oauth/status` | Returns the connection status for the authenticated caller (connected flag, account info, scopes, timestamp). |
 
 All endpoints rely on in-memory storage for demo purposes. Replace `GitHubOAuthService` with your persistence layer before shipping to production.
 
@@ -86,8 +86,8 @@ All endpoints rely on in-memory storage for demo purposes. Replace `GitHubOAuthS
 
 The **Integrations → GitHub connector** tab:
 
-1. Calls `GET /github/oauth/status` on mount when a user is signed in.
-2. Launches the GitHub OAuth flow by POSTing to `/github/oauth/start` and redirecting the browser to the returned URL.
+1. Calls `GET /github/oauth/status` on mount when a user is signed in, including the bearer token issued by Clerk (or your auth provider).
+2. Launches the GitHub OAuth flow by POSTing to `/github/oauth/start` and redirecting the browser to the returned URL, again sending the bearer token for identification.
 3. Listens for `github=connected` or `github=error` query parameters after the backend redirects back.
 4. Shows the connected account, scopes, and "Connected X minutes ago" timestamp.
 5. Links to this document so operators can review configuration steps without digging into the repository.

--- a/next.config.ts
+++ b/next.config.ts
@@ -39,6 +39,12 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/src/app/task/settings/keys/page.tsx
+++ b/src/app/task/settings/keys/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -8,12 +8,17 @@ import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
-import { Search, Plus, Key, Zap, Cloud, Code, MessageSquare, BarChart3, Settings } from 'lucide-react';
+import { Search, Plus, Key, Zap, Cloud, Code, MessageSquare, BarChart3, Settings, Github } from 'lucide-react';
 import { useAPIKeys, type APIKeyProvider } from '@/hooks/use-api-keys';
 import { APIKeyForm } from '@/components/settings/api-key-form';
 import { APIKeyList } from '@/components/settings/api-key-list';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useUser } from '@clerk/nextjs';
+import { toast } from 'sonner';
+
+import { useGitHubConnector } from '@/hooks/use-github-connector';
 
 const categoryIcons = {
   ai_models: Zap,
@@ -41,6 +46,39 @@ export default function KeyManagementPage() {
   const [selectedProvider, setSelectedProvider] = useState<APIKeyProvider | null>(null);
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [activeCategory, setActiveCategory] = useState<string>('all');
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { user } = useUser();
+  const {
+    startConnection: startGitHubConnection,
+    connecting: githubConnecting,
+  } = useGitHubConnector(user?.id, { autoFetch: false });
+
+  useEffect(() => {
+    const githubStatus = searchParams?.get('github');
+    if (!githubStatus) {
+      return;
+    }
+
+    const errorCode = searchParams?.get('error');
+
+    if (githubStatus === 'connected') {
+      toast.success('GitHub account connected.');
+    } else if (githubStatus === 'error') {
+      toast.error(errorCode ? 'GitHub authorization failed.' : 'GitHub authorization was cancelled.');
+    }
+
+    router.replace('/task/settings/keys');
+  }, [router, searchParams]);
+
+  const handleGitHubConnect = () => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const returnUrl = `${window.location.origin}/task/settings/keys?github=connected`;
+    startGitHubConnection({ returnTo: returnUrl });
+  };
 
   // Filter providers based on search query
   const filteredProviders = providers.filter(provider =>
@@ -162,6 +200,8 @@ export default function KeyManagementPage() {
           <ProvidersGrid
             providers={getProvidersForCategory(activeCategory)}
             onAddKey={handleAddKey}
+            onGitHubConnect={handleGitHubConnect}
+            githubConnecting={githubConnecting}
           />
         </TabsContent>
       </Tabs>
@@ -191,9 +231,11 @@ export default function KeyManagementPage() {
 interface ProvidersGridProps {
   providers: APIKeyProvider[];
   onAddKey: (provider: APIKeyProvider) => void;
+  onGitHubConnect: () => void;
+  githubConnecting: boolean;
 }
 
-function ProvidersGrid({ providers, onAddKey }: ProvidersGridProps) {
+function ProvidersGrid({ providers, onAddKey, onGitHubConnect, githubConnecting }: ProvidersGridProps) {
   const { getAPIKeysByProvider } = useAPIKeys();
 
   if (providers.length === 0) {
@@ -215,6 +257,8 @@ function ProvidersGrid({ providers, onAddKey }: ProvidersGridProps) {
       {providers.map((provider) => {
         const userKeys = getAPIKeysByProvider(provider.provider);
         const hasKeys = userKeys.length > 0;
+        const providerSlug = provider.provider?.toLowerCase?.() ?? '';
+        const isGitHubProvider = providerSlug === 'github';
 
         return (
           <Card key={provider.id} className="relative group hover:shadow-md transition-shadow">
@@ -250,7 +294,16 @@ function ProvidersGrid({ providers, onAddKey }: ProvidersGridProps) {
                 {provider.description}
               </CardDescription>
 
-              {hasKeys ? (
+              {isGitHubProvider ? (
+                <Button
+                  className="w-full gap-2"
+                  onClick={onGitHubConnect}
+                  disabled={githubConnecting}
+                >
+                  <Github className="w-4 h-4" />
+                  {githubConnecting ? 'Opening GitHub...' : 'Connect GitHub'}
+                </Button>
+              ) : hasKeys ? (
                 <APIKeyList provider={provider} onAddKey={() => onAddKey(provider)} />
               ) : (
                 <Button
@@ -261,6 +314,12 @@ function ProvidersGrid({ providers, onAddKey }: ProvidersGridProps) {
                   <Plus className="w-4 h-4 mr-2" />
                   Add {provider.displayName} Key
                 </Button>
+              )}
+
+              {isGitHubProvider && (
+                <p className="text-xs text-muted-foreground">
+                  Opens GitHub&apos;s Install &amp; Authorize page in a new tab. Once approved, the Async Coder backend completes the OAuth exchange and stores the installation token for this account.
+                </p>
               )}
 
               {provider.docsUrl && (

--- a/src/components/settings/settings-content.tsx
+++ b/src/components/settings/settings-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -8,16 +8,46 @@ import { GeneralTab } from './tabs/GeneralTab';
 import { EnvironmentsTab } from './tabs/EnvironmentsTab';
 import { DataControlsTab } from './tabs/DataControlsTab';
 import { CodeReviewTab } from './tabs/CodeReviewTab';
+import { IntegrationsTab } from './tabs/IntegrationsTab';
+import { useSearchParams, useRouter } from 'next/navigation';
 
 const settingsTabs = [
   { id: 'general', label: 'General', component: GeneralTab },
   { id: 'environments', label: 'Environments', component: EnvironmentsTab },
+  { id: 'integrations', label: 'Integrations', component: IntegrationsTab },
   { id: 'data-controls', label: 'Data controls', component: DataControlsTab },
   { id: 'code-review', label: 'Code review', component: CodeReviewTab },
 ];
 
 export function SettingsContent() {
   const [activeTab, setActiveTab] = useState('general');
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const tabFromQuery = searchParams?.get('tab');
+    if (!tabFromQuery) {
+      return;
+    }
+
+    const isValidTab = settingsTabs.some((tab) => tab.id === tabFromQuery);
+    if (isValidTab) {
+      setActiveTab(tabFromQuery);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!router) return;
+
+    const currentTab = searchParams?.get('tab');
+    if (currentTab === activeTab) {
+      return;
+    }
+
+    const params = new URLSearchParams(searchParams?.toString());
+    params.set('tab', activeTab);
+    router.replace(`?${params.toString()}`);
+  }, [activeTab, router, searchParams]);
 
   const ActiveComponent = settingsTabs.find(tab => tab.id === activeTab)?.component || GeneralTab;
 

--- a/src/components/settings/tabs/IntegrationsTab.tsx
+++ b/src/components/settings/tabs/IntegrationsTab.tsx
@@ -31,6 +31,10 @@ import {
 
 import { useGitHubConnector } from "@/hooks/use-github-connector";
 
+const docsLink =
+  process.env.NEXT_PUBLIC_GITHUB_CONNECTOR_DOCS ??
+  "https://github.com/your-org/async-coder/blob/main/docs/github-connector.md";
+
 const ENVIRONMENT_VARIABLES = [
   {
     key: "GITHUB_APP_ID",
@@ -191,6 +195,14 @@ export function IntegrationsTab() {
         <p className="text-sm text-neutral-300 max-w-3xl">
           Async Coder now guides people straight to GitHub&apos;s Install &amp; Authorize flow so every team member can connect their repositories without confusing pop-ups. The integration follows OpenAI&apos;s Model Context Protocol (MCP) playbook for custom connectors, keeping authentication simple and secure.
         </p>
+        <div>
+          <Button asChild variant="outline" className="gap-2 border-neutral-700 text-sm text-neutral-200 hover:bg-neutral-800">
+            <Link href={docsLink} target="_blank" rel="noopener noreferrer">
+              Open the full setup guide
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+          </Button>
+        </div>
       </header>
 
       <Card className="bg-neutral-900 border-neutral-800">
@@ -317,7 +329,7 @@ export function IntegrationsTab() {
         <CardHeader>
           <CardTitle className="text-white">Environment variables</CardTitle>
           <CardDescription className="text-neutral-300">
-            Configure these secrets so the backend can negotiate OAuth with GitHub and expose the connector to ChatGPT.
+            Configure these secrets (see <code className="mx-1 rounded bg-neutral-800 px-1.5 py-0.5 text-xs">backend/.env.example</code> and <code className="mx-1 rounded bg-neutral-800 px-1.5 py-0.5 text-xs">.env.local.example</code>) so the backend can negotiate OAuth with GitHub and expose the connector to ChatGPT.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/components/settings/tabs/IntegrationsTab.tsx
+++ b/src/components/settings/tabs/IntegrationsTab.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useEffect, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { formatDistanceToNow } from "date-fns";
+import { toast } from "sonner";
+
+import {
+  Badge,
+} from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Github,
+  Lock,
+  ArrowRight,
+  ShieldCheck,
+  ServerCog,
+  GitBranch,
+  ExternalLink,
+} from "lucide-react";
+
+import { useGitHubConnector } from "@/hooks/use-github-connector";
+
+const ENVIRONMENT_VARIABLES = [
+  {
+    key: "GITHUB_APP_ID",
+    description:
+      "Numeric identifier for your GitHub App. Found in the app's General settings page.",
+  },
+  {
+    key: "GITHUB_CLIENT_ID",
+    description:
+      "OAuth Client ID that GitHub provides. Used when exchanging the authorization code for a token.",
+  },
+  {
+    key: "GITHUB_CLIENT_SECRET",
+    description:
+      "OAuth Client Secret used to securely exchange authorization codes for access tokens.",
+  },
+  {
+    key: "GITHUB_PRIVATE_KEY",
+    description:
+      "PEM-formatted private key generated for the GitHub App. Required to mint installation access tokens.",
+  },
+  {
+    key: "GITHUB_WEBHOOK_SECRET",
+    description:
+      "Secret string used to verify webhook signatures from GitHub (optional but recommended).",
+  },
+  {
+    key: "FRONTEND_BASE_URL",
+    description:
+      "Base URL for the dashboard. Used when the backend redirects back after GitHub authorization.",
+  },
+  {
+    key: "MCP_CONNECTOR_URL",
+    description:
+      "Base URL of the MCP server that exposes repository actions to ChatGPT.",
+  },
+  {
+    key: "GITHUB_REDIRECT_URI",
+    description:
+      "Callback URL that handles the OAuth authorization code exchange inside your backend.",
+  },
+  {
+    key: "NEXT_PUBLIC_API_BASE_URL",
+    description:
+      "Frontend configuration pointing to this FastAPI backend (defaults to http://localhost:8000/api/v1).",
+  },
+];
+
+const CONNECTOR_FLOW = [
+  {
+    title: "User authorizes via GitHub",
+    description:
+      "Async Coder redirects the user directly to GitHub's Install & Authorize screen. No intermediary popups are required.",
+    details: [
+      "Use the OAuth authorization-code flow or GitHub App installation flow.",
+      "Request the minimal scopes needed (for example: repo, read:org).",
+    ],
+    icon: <Github className="w-5 h-5" />,
+  },
+  {
+    title: "Backend exchanges the code",
+    description:
+      "Your FastAPI backend stores the short-lived authorization code, exchanges it for an access or installation token, and persists the mapping to the authenticated user.",
+    details: [
+      "Validate the OAuth state parameter before exchanging the code.",
+      "Refresh or rotate installation tokens automatically before they expire.",
+    ],
+    icon: <ServerCog className="w-5 h-5" />,
+  },
+  {
+    title: "Expose actions via MCP",
+    description:
+      "ChatGPT calls the MCP server you host (the \"connector\") to fetch repositories, read files, or trigger workflows using the stored GitHub credentials.",
+    details: [
+      "Implement MCP methods such as listRepos, getFile, and searchCode.",
+      "Authorize every call with the user's GitHub installation token before reaching GitHub's REST or GraphQL APIs.",
+    ],
+    icon: <GitBranch className="w-5 h-5" />,
+  },
+  {
+    title: "Secure, auditable responses",
+    description:
+      "Responses from GitHub are sanitized, logged, and returned to ChatGPT, keeping the connector compliant with enterprise policies.",
+    details: [
+      "Store only encrypted tokens and rotate them on revocation events.",
+      "Emit audit logs (who accessed what) for compliance teams.",
+    ],
+    icon: <ShieldCheck className="w-5 h-5" />,
+  },
+];
+
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  configuration: "The GitHub connector is missing configuration values.",
+  invalid_state: "The authorization request expired. Please try again.",
+  network_failure: "We could not reach GitHub. Check your network and try again.",
+  token_exchange_failed: "GitHub rejected the authorization code. Try connecting again.",
+};
+
+function resolveOAuthError(code: string | null): string {
+  if (!code) {
+    return "GitHub authorization was cancelled.";
+  }
+
+  return OAUTH_ERROR_MESSAGES[code] ?? "GitHub authorization failed. Please try again.";
+}
+
+export function IntegrationsTab() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { user } = useUser();
+  const { status, isConnected, connecting, loadingStatus, startConnection, refreshStatus } =
+    useGitHubConnector(user?.id);
+
+  const connectedAtText = useMemo(() => {
+    if (!status?.connectedAt) {
+      return null;
+    }
+
+    const date = new Date(status.connectedAt);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return formatDistanceToNow(date, { addSuffix: true });
+  }, [status?.connectedAt]);
+
+  useEffect(() => {
+    if (!searchParams) return;
+
+    const githubStatus = searchParams.get("github");
+    if (!githubStatus) {
+      return;
+    }
+
+    const errorCode = searchParams.get("error");
+
+    if (githubStatus === "connected") {
+      toast.success("GitHub account connected.");
+      refreshStatus();
+    } else if (githubStatus === "error") {
+      toast.error(resolveOAuthError(errorCode));
+    }
+
+    router.replace("/task/settings?tab=integrations");
+  }, [searchParams, refreshStatus, router]);
+
+  const account = status?.account;
+  const hasScopes = Boolean(status?.scopes?.length);
+
+  return (
+    <div className="max-w-5xl space-y-10">
+      <header className="space-y-3">
+        <Badge variant="secondary" className="gap-1">
+          <Lock className="w-3 h-3" />
+          Secure integrations
+        </Badge>
+        <h1 className="text-3xl font-semibold text-white">GitHub connector</h1>
+        <p className="text-sm text-neutral-300 max-w-3xl">
+          Async Coder now guides people straight to GitHub&apos;s Install &amp; Authorize flow so every team member can connect their repositories without confusing pop-ups. The integration follows OpenAI&apos;s Model Context Protocol (MCP) playbook for custom connectors, keeping authentication simple and secure.
+        </p>
+      </header>
+
+      <Card className="bg-neutral-900 border-neutral-800">
+        <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <CardTitle className="flex items-center gap-2 text-white">
+              <Github className="w-5 h-5" />
+              {isConnected ? "GitHub connected" : "Connect GitHub directly"}
+            </CardTitle>
+            <CardDescription className="text-neutral-300">
+              {isConnected
+                ? `Connected as ${account?.login || account?.name || "your GitHub account"}. Async Coder securely stores the installation token in the backend.`
+                : "Click the button to open GitHub's native Install & Authorize page. Once the user approves, the backend will exchange the code and persist the token."}
+            </CardDescription>
+          </div>
+          <div className="flex flex-col items-stretch gap-2 sm:items-end sm:text-right">
+            {isConnected && (
+              <Badge variant="outline" className="self-start sm:self-end">
+                Connected
+              </Badge>
+            )}
+            <Button
+              size="lg"
+              className="gap-2"
+              onClick={() => startConnection()}
+              disabled={connecting}
+            >
+              {connecting
+                ? "Opening GitHub..."
+                : isConnected
+                  ? "Reconnect GitHub"
+                  : "Authorize with GitHub"}
+              <ArrowRight className="w-4 h-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => refreshStatus()}
+              disabled={loadingStatus}
+              className="mt-1"
+            >
+              {loadingStatus ? "Checking status..." : "Refresh status"}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-neutral-300">
+          {isConnected ? (
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-3">
+                {account?.avatarUrl && (
+                  <Image
+                    src={account.avatarUrl}
+                    alt="GitHub avatar"
+                    width={48}
+                    height={48}
+                    className="h-12 w-12 rounded-full border border-neutral-700"
+                  />
+                )}
+                <div className="space-y-1">
+                  <p className="text-white font-medium">
+                    {account?.login || account?.name || "GitHub user"}
+                  </p>
+                  {account?.htmlUrl && (
+                    <Link
+                      href={account.htmlUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-neutral-400 underline"
+                    >
+                      View profile
+                    </Link>
+                  )}
+                  {hasScopes && (
+                    <p className="text-xs text-neutral-400">
+                      Scopes: {status?.scopes?.join(", ")}
+                    </p>
+                  )}
+                  {connectedAtText && (
+                    <p className="text-xs text-neutral-500">
+                      Connected {connectedAtText}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <p className="text-xs text-neutral-400 max-w-sm">
+                The OAuth code exchange and token storage happen entirely in the FastAPI backend. Tokens never touch the browser.
+              </p>
+            </div>
+          ) : (
+            <p className="text-neutral-400">
+              Async Coder creates a short-lived OAuth state and redirects you to GitHub. After authorization, the backend trades the code for an installation token and associates it with your user account.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        {CONNECTOR_FLOW.map((step) => (
+          <Card key={step.title} className="border-neutral-800 bg-neutral-900">
+            <CardHeader className="flex flex-col gap-2">
+              <div className="flex items-center gap-2 text-white">
+                {step.icon}
+                <CardTitle className="text-lg">{step.title}</CardTitle>
+              </div>
+              <CardDescription className="text-neutral-300">
+                {step.description}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-2 text-sm text-neutral-400">
+                {step.details.map((detail) => (
+                  <li key={detail} className="flex gap-2">
+                    <span className="mt-1 block h-1.5 w-1.5 rounded-full bg-neutral-500" aria-hidden />
+                    <span>{detail}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <Card className="border-neutral-800 bg-neutral-900">
+        <CardHeader>
+          <CardTitle className="text-white">Environment variables</CardTitle>
+          <CardDescription className="text-neutral-300">
+            Configure these secrets so the backend can negotiate OAuth with GitHub and expose the connector to ChatGPT.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-hidden rounded-lg border border-neutral-800">
+            <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-neutral-800">
+              {ENVIRONMENT_VARIABLES.map((env) => (
+                <div key={env.key} className="p-4">
+                  <p className="font-mono text-sm text-white">{env.key}</p>
+                  <p className="mt-1 text-sm text-neutral-300">{env.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+          <p className="mt-4 text-xs text-neutral-500">
+            Need a refresher on GitHub Apps? Review the <Link href="https://docs.github.com/en/apps" target="_blank" rel="noopener noreferrer" className="underline">official documentation</Link> for generating keys and configuring callback URLs.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card className="border-neutral-800 bg-neutral-900">
+        <CardHeader>
+          <CardTitle className="text-white">Roll-out checklist</CardTitle>
+          <CardDescription className="text-neutral-300">
+            Follow these steps so every teammate can connect GitHub without friction.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ol className="list-decimal space-y-3 pl-5 text-sm text-neutral-300">
+            <li>
+              Register or reuse a GitHub App with the permissions you need (repository contents, pull requests, metadata, and optional organization access).
+            </li>
+            <li>
+              Populate the environment variables above and restart the Async Coder backend so new credentials are loaded safely.
+            </li>
+            <li>
+              Update your MCP discovery document to reference the connector&apos;s OAuth endpoints and absolute URLs.
+            </li>
+            <li>
+              Invite a teammate to open <code className="mx-1 rounded bg-neutral-800 px-1.5 py-0.5 text-xs">Settings → Integrations</code>, click <em>Authorize with GitHub</em>, and confirm they land on GitHub&apos;s Install screen.
+            </li>
+            <li>
+              Monitor the callback logs to verify that installation and access tokens are issued and encrypted at rest.
+            </li>
+          </ol>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Button asChild variant="outline" className="gap-2">
+              <Link
+                href="https://platform.openai.com/docs/actions#custom-actions"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Learn about MCP connectors
+                <ExternalLink className="w-4 h-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" className="gap-2">
+              <Link
+                href="https://github.com/OBannon37/chatgpt-deep-research-connector-example"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Example GitHub connector
+                <ExternalLink className="w-4 h-4" />
+              </Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/hooks/use-github-connector.ts
+++ b/src/hooks/use-github-connector.ts
@@ -1,0 +1,206 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000/api/v1';
+
+export interface GitHubConnectorAccount {
+  login?: string | null;
+  name?: string | null;
+  avatarUrl?: string | null;
+  htmlUrl?: string | null;
+}
+
+export interface GitHubConnectorStatus {
+  connected: boolean;
+  account: GitHubConnectorAccount | null;
+  scopes: string[];
+  connectedAt: string | null;
+}
+
+interface RawStatusAccount {
+  login?: string | null;
+  name?: string | null;
+  avatarUrl?: string | null;
+  avatar_url?: string | null;
+  htmlUrl?: string | null;
+  html_url?: string | null;
+}
+
+interface RawStatusPayload {
+  connected?: boolean;
+  account?: RawStatusAccount | null;
+  scopes?: string[] | null;
+  connectedAt?: string | null;
+  connected_at?: string | null;
+}
+
+interface StartConnectionOptions {
+  returnTo?: string;
+}
+
+interface UseGitHubConnectorOptions {
+  autoFetch?: boolean;
+}
+
+const buildAuthHeaders = (): Record<string, string> => {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  const token = localStorage.getItem('auth_token');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+const normalizeStatus = (payload: RawStatusPayload | null | undefined): GitHubConnectorStatus => {
+  if (!payload || !payload.connected) {
+    return {
+      connected: false,
+      account: null,
+      scopes: [],
+      connectedAt: null,
+    };
+  }
+
+  const account = payload.account || {};
+
+  return {
+    connected: true,
+    account: {
+      login: account.login ?? null,
+      name: account.name ?? null,
+      avatarUrl: account.avatarUrl ?? account.avatar_url ?? null,
+      htmlUrl: account.htmlUrl ?? account.html_url ?? null,
+    },
+    scopes: Array.isArray(payload.scopes) ? payload.scopes : [],
+    connectedAt: payload.connectedAt ?? payload.connected_at ?? null,
+  };
+};
+
+export function useGitHubConnector(
+  userId?: string | null,
+  options?: UseGitHubConnectorOptions,
+) {
+  const [status, setStatus] = useState<GitHubConnectorStatus | null>(null);
+  const [connecting, setConnecting] = useState(false);
+  const [loadingStatus, setLoadingStatus] = useState(false);
+
+  const autoFetch = options?.autoFetch ?? true;
+
+  const refreshStatus = useCallback(async (): Promise<GitHubConnectorStatus> => {
+    if (!userId) {
+      const emptyStatus: GitHubConnectorStatus = {
+        connected: false,
+        account: null,
+        scopes: [],
+        connectedAt: null,
+      };
+      setStatus(null);
+      return emptyStatus;
+    }
+
+    setLoadingStatus(true);
+    try {
+      const params = new URLSearchParams({ user_id: userId });
+      const response = await fetch(`${API_BASE_URL}/github/oauth/status?${params.toString()}`, {
+        headers: {
+          Accept: 'application/json',
+          ...buildAuthHeaders(),
+        },
+      });
+
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        if (response.status >= 500) {
+          console.error('GitHub status request failed', data);
+        }
+        const normalized = normalizeStatus(null);
+        setStatus(null);
+        return normalized;
+      }
+
+      const normalized = normalizeStatus(data);
+      setStatus(normalized.connected ? normalized : null);
+      return normalized;
+    } catch (error) {
+      console.error('Error fetching GitHub connection status', error);
+      const normalized = normalizeStatus(null);
+      setStatus(null);
+      return normalized;
+    } finally {
+      setLoadingStatus(false);
+    }
+  }, [userId]);
+
+  const startConnection = useCallback(
+    async (startOptions?: StartConnectionOptions) => {
+      if (!userId) {
+        toast.error('You need to be signed in to connect GitHub.');
+        return;
+      }
+
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      const returnTo = startOptions?.returnTo || `${window.location.origin}/task/settings?tab=integrations`;
+
+      setConnecting(true);
+      try {
+        const response = await fetch(`${API_BASE_URL}/github/oauth/start`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            ...buildAuthHeaders(),
+          },
+          body: JSON.stringify({
+            user_id: userId,
+            return_url: returnTo,
+          }),
+        });
+
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+          const message = data.detail || data.message || 'Unable to start GitHub authorization.';
+          toast.error(message);
+          return;
+        }
+
+        const authorizationUrl = data.authorizationUrl || data.authorization_url;
+        if (!authorizationUrl) {
+          toast.error('GitHub authorization URL was missing from the response.');
+          return;
+        }
+
+        window.location.assign(authorizationUrl);
+      } catch (error) {
+        console.error('Error starting GitHub OAuth flow', error);
+        toast.error('Failed to start GitHub authorization.');
+      } finally {
+        setConnecting(false);
+      }
+    },
+    [userId],
+  );
+
+  useEffect(() => {
+    if (autoFetch) {
+      refreshStatus().catch(() => undefined);
+    }
+  }, [autoFetch, refreshStatus]);
+
+  const isConnected = useMemo(() => Boolean(status?.connected), [status]);
+
+  return {
+    status,
+    isConnected,
+    connecting,
+    loadingStatus,
+    startConnection,
+    refreshStatus,
+  };
+}

--- a/src/hooks/use-github-connector.ts
+++ b/src/hooks/use-github-connector.ts
@@ -102,8 +102,7 @@ export function useGitHubConnector(
 
     setLoadingStatus(true);
     try {
-      const params = new URLSearchParams({ user_id: userId });
-      const response = await fetch(`${API_BASE_URL}/github/oauth/status?${params.toString()}`, {
+      const response = await fetch(`${API_BASE_URL}/github/oauth/status`, {
         headers: {
           Accept: 'application/json',
           ...buildAuthHeaders(),
@@ -157,7 +156,6 @@ export function useGitHubConnector(
             ...buildAuthHeaders(),
           },
           body: JSON.stringify({
-            user_id: userId,
             return_url: returnTo,
           }),
         });


### PR DESCRIPTION
## Summary
- add a FastAPI GitHub OAuth service and endpoints that generate authorization URLs, exchange codes, and report connection status
- build a reusable GitHub connector hook and wire the Integrations and Key Management settings views to the backend-driven flow with success and error handling
- keep settings tabs in sync with the URL query and allow optimized GitHub avatars via next/image configuration

## Testing
- npm run lint
- pytest *(fails: missing requests dependency in backend test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d63f27f37c832dabd7f7fb8e99bc48